### PR TITLE
Add a simple json with last 5 post

### DIFF
--- a/_src/feed.json
+++ b/_src/feed.json
@@ -1,0 +1,15 @@
+---
+layout: nil
+---
+
+[
+{% for post in site.posts limit:5 %}
+    {
+      "title": "{{ post.title }}",
+      "url": "{{ post.url | prepend: site.baseurl | prepend: site.url }}",
+      "category": "{% assign sortedcategories = post.categories | sort %}{% for category in sortedcategories %}{{ category }}{% endfor %}",
+      "date": "{{ post.date | date: "%B %d, %Y" }}",
+      "lala": "{{ post.content | strip_html | truncatewords: 50 }}"
+} {% if forloop.last %}{% else %},{% endif %}
+{% endfor %}
+]


### PR DESCRIPTION
This PR creates a json file listing last 5 post. The idea is to have CORS enable on this bucket and consume the json on the new landing page with js.

This article explains CORS on the AWS ecosystem http://docs.aws.amazon.com/AmazonS3/latest/dev/cors.html